### PR TITLE
Add navigation from home to corporate subpages

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,10 +260,10 @@
             </div>
             <nav>
                 <ul>
-                    <li><a href="#about">会社概要</a></li>
-                    <li><a href="#service">事業内容</a></li>
-                    <li><a href="#news">お知らせ</a></li>
-                    <li><a href="#contact">お問い合わせ</a></li>
+                    <li><a href="index.html">ホーム</a></li>
+                    <li><a href="pages/about.html">このサイトについて</a></li>
+                    <li><a href="pages/services.html">サービス</a></li>
+                    <li><a href="pages/contact.html">お問い合わせ</a></li>
                 </ul>
             </nav>
         </div>


### PR DESCRIPTION
## Summary
- Link home page header navigation to separate About, Services, and Contact pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68931e929658832fb685d986c3e0f58a